### PR TITLE
Add names to builders

### DIFF
--- a/template.json
+++ b/template.json
@@ -28,6 +28,7 @@
     "builders": [
         {
             "type": "virtualbox-iso",
+            "name": "virtualbox",
             "boot_command": [
                 "<esc><esc><enter><wait>",
                 "/install/vmlinuz noapic preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/preseed.cfg ",
@@ -55,6 +56,7 @@
         },
         {
             "type": "vmware-iso",
+            "name": "vmware",
             "boot_command": [
                 "<esc><esc><enter><wait>",
                 "/install/vmlinuz noapic preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/preseed.cfg ",


### PR DESCRIPTION
So that the build output doesn't look duplicated: ![](http://cl.ly/image/1f0Y2N0D173a/Screen%20Shot%202015-04-16%20at%204.46.01%20PM.png)
